### PR TITLE
ci: fix caller workflows for ci-tests and pre-commit-autoupdate

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -19,3 +19,4 @@ jobs:
 
   pre-commits:
     uses: observeinc/.github/.github/workflows/terraform-observe_pre-commit.yaml@main
+    secrets: inherit

--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -9,5 +9,6 @@ on:
 
 jobs:
   auto-update:
-    uses: observeinc/.github/.github/workflows/terraform-observe_pre-commit-autoupdate.yaml@main
+    if: github.repository == 'observeinc/terraform-observe-example'
+    uses: observeinc/.github/.github/workflows/pre-commit-autoupdate.yaml@main
     secrets: inherit


### PR DESCRIPTION
## What does this PR do?

1. Passes secrets from caller workflow to `terraform-observe_pre-commit.yaml` workflow
2. Uses newly named `pre-commit-autoupdate.yaml` workflow instead of `terraform-observe_pre-commit-autoupdate.yaml`
3. Adds conditional to only run `pre-commit-autoupdate.yaml` workflow from template repo, not from repos generated as templates (this is to avoid git conflicts between the `pre-commit-autoupdate.yaml` workflow and the `terraform-observe_sync-from-template-repo.yaml` workflow, which all the children repos will be running). 

## Motivation

Fix tests!

## Testing

- I've tested `1` on a separate test repo. 
- I tested `2` on the [example repo here](https://github.com/observeinc/terraform-observe-example/actions/runs/2429553278)
- I tested the logic of `3` in a different repo test [here](https://github.com/observeinc/terraform-observe-estib-test2/actions/runs/2417374038)