### PR TITLE
feat: added nginx ingress metrics and boards for Ingress and Pod resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ terraform.tfstate
 terraform.tfvars
 
 .terraform.lock.hcl
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -103,20 +103,26 @@ No modules.
 
 | Name | Type |
 |------|------|
+| observe_board.ingress | resource |
+| observe_board.pod | resource |
 | observe_dataset.ingress_logs | resource |
+| observe_dataset.metrics | resource |
 | observe_link.ingress_logs | resource |
+| observe_link.metrics | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_container_name"></a> [container\_name](#input\_container\_name) | Filter expression on container logs. | `string` | `"nginx-ingress-controller"` | no |
+| <a name="input_enable_nginx_ingress_metrics"></a> [enable\_nginx\_ingress\_metrics](#input\_enable\_nginx\_ingress\_metrics) | Flag to enable or disable nginx ingress metrics. | `bool` | `true` | no |
 | <a name="input_freshness_default"></a> [freshness\_default](#input\_freshness\_default) | Default dataset freshness. Can be overridden with freshness input | `string` | `"1m"` | no |
-| <a name="input_kubernetes"></a> [kubernetes](#input\_kubernetes) | Kubernetes module. | <pre>object({<br>    container_logs = object({ oid = string })<br>    endpoint       = object({ oid = string })<br>  })</pre> | n/a | yes |
+| <a name="input_kubernetes"></a> [kubernetes](#input\_kubernetes) | Kubernetes module. | <pre>object({<br>    container_logs = object({ oid = string })<br>    endpoint       = object({ oid = string })<br>    ingress        = object({ oid = string })<br>    pod            = object({ oid = string })<br>    namespace      = object({ oid = string })<br>    cluster        = object({ oid = string })<br>  })</pre> | n/a | yes |
 | <a name="input_link_targets"></a> [link\_targets](#input\_link\_targets) | Datasets to link to. | <pre>map(object({<br>    target = string<br>    fields = list(string)<br>  }))</pre> | `{}` | no |
 | <a name="input_log_format"></a> [log\_format](#input\_log\_format) | Log format version. | `string` | `"latest"` | no |
 | <a name="input_name_format"></a> [name\_format](#input\_name\_format) | Format string to use for dataset names. Override to introduce a prefix or suffix. | `string` | `"%s"` | no |
 | <a name="input_pipeline_custom"></a> [pipeline\_custom](#input\_pipeline\_custom) | Pipeline to parse additional data appended to log lines, surfaced in the `remainder` field. | `string` | `null` | no |
+| <a name="input_pod_metrics"></a> [pod\_metrics](#input\_pod\_metrics) | Prometheus pod metrics module. | <pre>object({<br>    metrics = object({ oid = string })<br>  })</pre> | n/a | yes |
 | <a name="input_workspace"></a> [workspace](#input\_workspace) | Workspace to apply module to. | `object({ oid = string })` | n/a | yes |
 
 ## Outputs

--- a/boards/nginxIngressBoard.json
+++ b/boards/nginxIngressBoard.json
@@ -1,0 +1,438 @@
+{
+  "bindings": {
+    "dataset_kubernetes_cluster": "${dataset_kubernetes_cluster}",
+    "dataset_kubernetes_ingress": "${dataset_kubernetes_ingress}",
+    "dataset_kubernetes_namespace": "${dataset_kubernetes_namespace}",
+    "dataset_nginx-ingress_nginxIngressMetrics": "${ingress_nginxIngressMetrics}"
+  },
+  "sections": [
+    {
+      "card": {
+        "cardType": "section",
+        "closed": false,
+        "title": "OVERVIEW"
+      },
+      "items": [
+        {
+          "card": {
+            "cardType": "datavis",
+            "title": "Cluster",
+            "visualization": {
+              "config": {
+                "innerRadius": 0.6,
+                "legend": {
+                  "placement": "right",
+                  "type": "list",
+                  "visible": true
+                },
+                "type": "arc"
+              },
+              "source": {
+                "stat": {
+                  "link": {
+                    "dstFields": [
+                      "uid"
+                    ],
+                    "label": "Cluster",
+                    "srcFields": [
+                      "clusterUid"
+                    ],
+                    "targetDataset": "$dataset_kubernetes_cluster",
+                    "targetLabelField": "name",
+                    "type": "linked"
+                  }
+                },
+                "type": "stats"
+              },
+              "type": "circular"
+            }
+          },
+          "layout": {
+            "h": 9,
+            "w": 6,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "card": {
+            "cardType": "datavis",
+            "title": "Namespace",
+            "visualization": {
+              "config": {
+                "innerRadius": 0.6,
+                "legend": {
+                  "placement": "right",
+                  "type": "list",
+                  "visible": true
+                },
+                "type": "arc"
+              },
+              "source": {
+                "stat": {
+                  "link": {
+                    "dstFields": [
+                      "clusterUid",
+                      "name"
+                    ],
+                    "label": "Namespace",
+                    "srcFields": [
+                      "clusterUid",
+                      "namespace"
+                    ],
+                    "targetDataset": "$dataset_kubernetes_namespace",
+                    "targetLabelField": "name",
+                    "type": "linked"
+                  }
+                },
+                "type": "stats"
+              },
+              "type": "circular"
+            }
+          },
+          "layout": {
+            "h": 9,
+            "w": 6,
+            "x": 6,
+            "y": 0
+          }
+        }
+      ]
+    },
+    {
+      "card": {
+        "cardType": "section",
+        "closed": false,
+        "title": "MONITORING"
+      },
+      "items": [
+        {
+          "card": {
+            "cardType": "datavis",
+            "title": "Requests",
+            "visualization": {
+              "config": {
+                "color": "Default",
+                "hideGridLines": true,
+                "legend": {
+                  "placement": "right",
+                  "type": "list"
+                },
+                "type": "xy",
+                "xConfig": {
+                  "visible": true
+                },
+                "yConfig": {
+                  "unit": "",
+                  "visible": true
+                }
+              },
+              "source": {
+                "metric": {
+                  "aggregate": "max",
+                  "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                  "description": "Auto Detected Metric",
+                  "groupBy": [
+                    [
+                      "ingress",
+                      "exported_namespace",
+                      "clusterUid"
+                    ],
+                    "status"
+                  ],
+                  "heuristics": null,
+                  "id": {
+                    "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                    "name": "nginx_ingress_controller_requests"
+                  },
+                  "interval": null,
+                  "link": {
+                    "__typename": "ForeignKey",
+                    "dstFields": [
+                      "name",
+                      "namespace",
+                      "clusterUid"
+                    ],
+                    "label": "Ingress",
+                    "srcFields": [
+                      "ingress",
+                      "exported_namespace",
+                      "clusterUid"
+                    ],
+                    "targetDataset": "$dataset_kubernetes_ingress",
+                    "targetStageLabel": null,
+                    "type": "foreign"
+                  },
+                  "name": "nginx_ingress_controller_requests",
+                  "rollup": "rate",
+                  "type": "gauge",
+                  "unit": "",
+                  "userDefined": false
+                },
+                "type": "metric"
+              },
+              "type": "timeseries"
+            }
+          },
+          "layout": {
+            "h": 27,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "card": {
+            "cardType": "datavis",
+            "title": "Response Latency",
+            "visualization": {
+              "config": {
+                "color": "Default",
+                "hideGridLines": true,
+                "legend": {
+                  "placement": "right",
+                  "type": "list"
+                },
+                "type": "xy",
+                "xConfig": {
+                  "visible": true
+                },
+                "yConfig": {
+                  "unit": "seconds",
+                  "visible": true
+                }
+              },
+              "source": {
+                "metric": {
+                  "aggregate": "avg",
+                  "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                  "description": "Auto Detected Metric",
+                  "groupBy": [
+                    "ingress",
+                    "exported_namespace",
+                    "clusterUid"
+                  ],
+                  "heuristics": null,
+                  "id": {
+                    "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                    "name": "nginx_ingress_controller_response_latency_per_request"
+                  },
+                  "interval": null,
+                  "link": {
+                    "__typename": "ForeignKey",
+                    "dstFields": [
+                      "name",
+                      "namespace",
+                      "clusterUid"
+                    ],
+                    "label": "Ingress",
+                    "srcFields": [
+                      "ingress",
+                      "exported_namespace",
+                      "clusterUid"
+                    ],
+                    "targetDataset": "$dataset_kubernetes_ingress",
+                    "targetStageLabel": null,
+                    "type": "foreign"
+                  },
+                  "name": "nginx_ingress_controller_response_latency_per_request",
+                  "rollup": "avg",
+                  "type": "gauge",
+                  "unit": "",
+                  "userDefined": false
+                },
+                "type": "metric"
+              },
+              "type": "timeseries"
+            }
+          },
+          "layout": {
+            "h": 15,
+            "w": 4,
+            "x": 4,
+            "y": 25
+          }
+        },
+        {
+          "card": {
+            "cardType": "datavis",
+            "title": "Request",
+            "visualization": {
+              "config": {
+                "color": "Default",
+                "hideGridLines": true,
+                "legend": {
+                  "placement": "right",
+                  "type": "list"
+                },
+                "type": "xy",
+                "xConfig": {
+                  "visible": false
+                },
+                "yConfig": {
+                  "unit": "seconds",
+                  "visible": true
+                }
+              },
+              "source": {
+                "metric": {
+                  "aggregate": "avg",
+                  "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                  "description": "Auto Detected Metric",
+                  "groupBy": [
+                    "ingress",
+                    "exported_namespace",
+                    "clusterUid"
+                  ],
+                  "heuristics": null,
+                  "id": {
+                    "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                    "name": "nginx_ingress_controller_request_latency_per_request"
+                  },
+                  "interval": null,
+                  "link": {
+                    "__typename": "ForeignKey",
+                    "dstFields": [
+                      "name",
+                      "namespace",
+                      "clusterUid"
+                    ],
+                    "label": "Ingress",
+                    "srcFields": [
+                      "ingress",
+                      "exported_namespace",
+                      "clusterUid"
+                    ],
+                    "targetDataset": "$dataset_kubernetes_ingress",
+                    "targetStageLabel": null,
+                    "type": "foreign"
+                  },
+                  "name": "nginx_ingress_controller_request_latency_per_request",
+                  "rollup": "avg",
+                  "type": "gauge",
+                  "unit": "",
+                  "userDefined": false
+                },
+                "type": "metric"
+              },
+              "type": "timeseries"
+            }
+          },
+          "layout": {
+            "h": 15,
+            "w": 4,
+            "x": 0,
+            "y": 25
+          }
+        },
+        {
+          "card": {
+            "cardType": "datavis",
+            "title": "Upstream Latency",
+            "visualization": {
+              "config": {
+                "color": "Default",
+                "hideGridLines": true,
+                "legend": {
+                  "placement": "right",
+                  "type": "list"
+                },
+                "type": "xy",
+                "xConfig": {
+                  "visible": false
+                },
+                "yConfig": {
+                  "unit": "seconds",
+                  "visible": true
+                }
+              },
+              "source": {
+                "metric": {
+                  "aggregate": "avg",
+                  "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                  "description": "Auto Detected Metric",
+                  "groupBy": [
+                    "ingress",
+                    "exported_namespace",
+                    "clusterUid"
+                  ],
+                  "heuristics": null,
+                  "id": {
+                    "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                    "name": "nginx_ingress_controller_response_upstream_latency_per_request"
+                  },
+                  "interval": null,
+                  "link": {
+                    "__typename": "ForeignKey",
+                    "dstFields": [
+                      "name",
+                      "namespace",
+                      "clusterUid"
+                    ],
+                    "label": "Ingress",
+                    "srcFields": [
+                      "ingress",
+                      "exported_namespace",
+                      "clusterUid"
+                    ],
+                    "targetDataset": "$dataset_kubernetes_ingress",
+                    "targetStageLabel": null,
+                    "type": "foreign"
+                  },
+                  "name": "nginx_ingress_controller_response_upstream_latency_per_request",
+                  "rollup": "avg",
+                  "type": "gauge",
+                  "unit": "",
+                  "userDefined": false
+                },
+                "type": "metric"
+              },
+              "type": "timeseries"
+            }
+          },
+          "layout": {
+            "h": 15,
+            "w": 4,
+            "x": 8,
+            "y": 25
+          }
+        }
+      ]
+    },
+    {
+      "card": {
+        "cardType": "section",
+        "closed": false,
+        "title": "DOCUMENTATION"
+      },
+      "items": [
+        {
+          "card": {
+            "cardType": "text",
+            "text": "# Notes\nObserve exposes request, response, and upstream latencies on the ingress resources themselves.  For monitoring requests, connections, resource consumption, and config reload errors/success, graphlink to the pod resource where the controller is deployed.\n\nFrom here, you can GraphLink to:\n* Ingress Logs\n* Container Logs\n* Cluster",
+            "title": "Text"
+          },
+          "layout": {
+            "h": 15,
+            "w": 6,
+            "x": 6,
+            "y": 0
+          }
+        },
+        {
+          "card": {
+            "cardType": "text",
+            "text": "# NGINX Ingress\nhttps://kubernetes.io/docs/concepts/services-networking/ingress/\n\nIngress exposes HTTP and HTTPS routes from outside the cluster to services within the cluster. Traffic routing is controlled by rules defined on the Ingress resource.\n\nAn Ingress may be configured to give Services externally-reachable URLs, load balance traffic, terminate SSL / TLS, and offer name-based virtual hosting. An Ingress controller is responsible for fulfilling the Ingress, usually with a load balancer, though it may also configure your edge router or additional frontends to help handle the traffic.",
+            "title": "Text"
+          },
+          "layout": {
+            "h": 15,
+            "w": 6,
+            "x": 0,
+            "y": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/boards/nginxIngressPodBoard.json
+++ b/boards/nginxIngressPodBoard.json
@@ -1,0 +1,650 @@
+{
+  "bindings": {
+    "dataset_kubernetes_cluster": "${dataset_kubernetes_cluster}",
+    "dataset_kubernetes_namespace": "${dataset_kubernetes_namespace}",
+    "dataset_kubernetes_pod": "${dataset_kubernetes_pod}",
+    "dataset_nginx-ingress_nginxIngressMetrics": "${dataset_nginx-ingress_nginxIngressMetrics}",
+    "dataset_prometheus_podMetrics": "${dataset_prometheus_podMetrics}"
+  },
+  "sections": [
+    {
+      "card": {
+        "cardType": "section",
+        "closed": false,
+        "title": "OVERVIEW"
+      },
+      "items": [
+        {
+          "card": {
+            "cardType": "datavis",
+            "title": "Cluster",
+            "visualization": {
+              "config": {
+                "innerRadius": 0.6,
+                "legend": {
+                  "placement": "right",
+                  "type": "list",
+                  "visible": true
+                },
+                "type": "arc"
+              },
+              "source": {
+                "stat": {
+                  "link": {
+                    "dstFields": [
+                      "uid"
+                    ],
+                    "label": "Cluster",
+                    "srcFields": [
+                      "clusterUid"
+                    ],
+                    "targetDataset": "$dataset_kubernetes_cluster",
+                    "targetLabelField": "name",
+                    "type": "linked"
+                  }
+                },
+                "type": "stats"
+              },
+              "type": "circular"
+            }
+          },
+          "layout": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "card": {
+            "cardType": "datavis",
+            "title": "Namespace",
+            "visualization": {
+              "config": {
+                "innerRadius": 0.6,
+                "legend": {
+                  "placement": "right",
+                  "type": "list",
+                  "visible": true
+                },
+                "type": "arc"
+              },
+              "source": {
+                "stat": {
+                  "link": {
+                    "dstFields": [
+                      "clusterUid",
+                      "name"
+                    ],
+                    "label": "Namespace",
+                    "srcFields": [
+                      "clusterUid",
+                      "namespace"
+                    ],
+                    "targetDataset": "$dataset_kubernetes_namespace",
+                    "targetLabelField": "name",
+                    "type": "linked"
+                  }
+                },
+                "type": "stats"
+              },
+              "type": "circular"
+            }
+          },
+          "layout": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 0
+          }
+        }
+      ]
+    },
+    {
+      "card": {
+        "cardType": "section",
+        "closed": false,
+        "title": "MONITORING"
+      },
+      "items": [
+        {
+          "card": {
+            "cardType": "datavis",
+            "title": "0=failed,1=succeeded",
+            "visualization": {
+              "config": {
+                "color": "Default",
+                "colorConfigType": "Color",
+                "fieldConfig": {
+                  "visible": false
+                },
+                "singleStatLabel": "0=failed,1=succeeded",
+                "thresholds": null,
+                "type": "singlefield"
+              },
+              "source": {
+                "metric": {
+                  "aggregate": "min",
+                  "datasetId": "$dataset_prometheus_podMetrics",
+                  "description": "Auto Detected Metric",
+                  "groupBy": [
+                    "clusterUid",
+                    "namespace",
+                    "pod"
+                  ],
+                  "heuristics": null,
+                  "id": {
+                    "datasetId": "$dataset_prometheus_podMetrics",
+                    "name": "nginx_ingress_controller_config_last_reload_successful"
+                  },
+                  "interval": null,
+                  "link": {
+                    "__typename": "ForeignKey",
+                    "dstFields": [
+                      "clusterUid",
+                      "namespace",
+                      "name"
+                    ],
+                    "label": "Pod",
+                    "srcFields": [
+                      "clusterUid",
+                      "namespace",
+                      "pod"
+                    ],
+                    "targetDataset": "$dataset_kubernetes_pod",
+                    "targetStageLabel": null,
+                    "type": "foreign"
+                  },
+                  "name": "nginx_ingress_controller_config_last_reload_successful",
+                  "rollup": "min",
+                  "type": "gauge",
+                  "unit": "",
+                  "userDefined": false
+                },
+                "type": "metric"
+              },
+              "type": "singlevalue"
+            }
+          },
+          "layout": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "card": {
+            "cardType": "datavis",
+            "title": "nginx_ingress_controller_check_errors",
+            "visualization": {
+              "config": {
+                "color": "Red",
+                "colorConfigType": "Color",
+                "fieldConfig": {
+                  "visible": false
+                },
+                "singleStatLabel": "Total",
+                "thresholds": null,
+                "type": "singlefield"
+              },
+              "source": {
+                "metric": {
+                  "aggregate": "max",
+                  "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                  "description": "Auto Detected Metric",
+                  "groupBy": [
+                    "controller_pod",
+                    "controller_namespace",
+                    "clusterUid"
+                  ],
+                  "heuristics": null,
+                  "id": {
+                    "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                    "name": "nginx_ingress_controller_check_errors"
+                  },
+                  "interval": null,
+                  "link": {
+                    "__typename": "ForeignKey",
+                    "dstFields": [
+                      "name",
+                      "namespace",
+                      "clusterUid"
+                    ],
+                    "label": "Pod",
+                    "srcFields": [
+                      "controller_pod",
+                      "controller_namespace",
+                      "clusterUid"
+                    ],
+                    "targetDataset": "$dataset_kubernetes_pod",
+                    "targetStageLabel": null,
+                    "type": "foreign"
+                  },
+                  "name": "nginx_ingress_controller_check_errors",
+                  "rollup": "max",
+                  "type": "gauge",
+                  "unit": "",
+                  "userDefined": false
+                },
+                "type": "metric"
+              },
+              "type": "singlevalue"
+            }
+          },
+          "layout": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 0
+          }
+        },
+        {
+          "card": {
+            "cardType": "datavis",
+            "title": "Upstream Latency",
+            "visualization": {
+              "config": {
+                "color": "Default",
+                "hideGridLines": true,
+                "legend": {
+                  "placement": "right",
+                  "type": "list"
+                },
+                "type": "xy",
+                "xConfig": {
+                  "visible": true
+                },
+                "yConfig": {
+                  "unit": "seconds",
+                  "visible": true
+                }
+              },
+              "source": {
+                "metric": {
+                  "aggregate": "avg",
+                  "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                  "description": "Auto Detected Metric",
+                  "groupBy": [
+                    "controller_pod",
+                    "controller_namespace",
+                    "clusterUid"
+                  ],
+                  "heuristics": null,
+                  "id": {
+                    "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                    "name": "nginx_ingress_controller_response_upstream_latency_per_request"
+                  },
+                  "interval": null,
+                  "link": {
+                    "__typename": "ForeignKey",
+                    "dstFields": [
+                      "name",
+                      "namespace",
+                      "clusterUid"
+                    ],
+                    "label": "Pod",
+                    "srcFields": [
+                      "controller_pod",
+                      "controller_namespace",
+                      "clusterUid"
+                    ],
+                    "targetDataset": "$dataset_kubernetes_pod",
+                    "targetStageLabel": null,
+                    "type": "foreign"
+                  },
+                  "name": "nginx_ingress_controller_response_upstream_latency_per_request",
+                  "rollup": "avg",
+                  "type": "gauge",
+                  "unit": "",
+                  "userDefined": false
+                },
+                "type": "metric"
+              },
+              "type": "timeseries"
+            }
+          },
+          "layout": {
+            "h": 15,
+            "w": 4,
+            "x": 0,
+            "y": 6
+          }
+        },
+        {
+          "card": {
+            "cardType": "datavis",
+            "title": "Request Latency",
+            "visualization": {
+              "config": {
+                "color": "Default",
+                "hideGridLines": true,
+                "legend": {
+                  "placement": "right",
+                  "type": "list"
+                },
+                "type": "xy",
+                "xConfig": {
+                  "visible": true
+                },
+                "yConfig": {
+                  "unit": "seconds",
+                  "visible": true
+                }
+              },
+              "source": {
+                "metric": {
+                  "aggregate": "avg",
+                  "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                  "description": "Auto Detected Metric",
+                  "groupBy": [
+                    "controller_pod",
+                    "controller_namespace",
+                    "clusterUid"
+                  ],
+                  "heuristics": null,
+                  "id": {
+                    "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                    "name": "nginx_ingress_controller_request_latency_per_request"
+                  },
+                  "interval": null,
+                  "link": {
+                    "__typename": "ForeignKey",
+                    "dstFields": [
+                      "name",
+                      "namespace",
+                      "clusterUid"
+                    ],
+                    "label": "Pod",
+                    "srcFields": [
+                      "controller_pod",
+                      "controller_namespace",
+                      "clusterUid"
+                    ],
+                    "targetDataset": "$dataset_kubernetes_pod",
+                    "targetStageLabel": null,
+                    "type": "foreign"
+                  },
+                  "name": "nginx_ingress_controller_request_latency_per_request",
+                  "rollup": "avg",
+                  "type": "gauge",
+                  "unit": "",
+                  "userDefined": false
+                },
+                "type": "metric"
+              },
+              "type": "timeseries"
+            }
+          },
+          "layout": {
+            "h": 15,
+            "w": 4,
+            "x": 8,
+            "y": 6
+          }
+        },
+        {
+          "card": {
+            "cardType": "datavis",
+            "title": "Response Latency",
+            "visualization": {
+              "config": {
+                "color": "Default",
+                "hideGridLines": true,
+                "legend": {
+                  "placement": "right",
+                  "type": "list"
+                },
+                "type": "xy",
+                "xConfig": {
+                  "visible": true
+                },
+                "yConfig": {
+                  "unit": "seconds",
+                  "visible": true
+                }
+              },
+              "source": {
+                "metric": {
+                  "aggregate": "avg",
+                  "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                  "description": "Auto Detected Metric",
+                  "groupBy": [
+                    "controller_pod",
+                    "controller_namespace",
+                    "clusterUid"
+                  ],
+                  "heuristics": null,
+                  "id": {
+                    "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                    "name": "nginx_ingress_controller_response_latency_per_request"
+                  },
+                  "interval": null,
+                  "link": {
+                    "__typename": "ForeignKey",
+                    "dstFields": [
+                      "name",
+                      "namespace",
+                      "clusterUid"
+                    ],
+                    "label": "Pod",
+                    "srcFields": [
+                      "controller_pod",
+                      "controller_namespace",
+                      "clusterUid"
+                    ],
+                    "targetDataset": "$dataset_kubernetes_pod",
+                    "targetStageLabel": null,
+                    "type": "foreign"
+                  },
+                  "name": "nginx_ingress_controller_response_latency_per_request",
+                  "rollup": "avg",
+                  "type": "gauge",
+                  "unit": "",
+                  "userDefined": false
+                },
+                "type": "metric"
+              },
+              "type": "timeseries"
+            }
+          },
+          "layout": {
+            "h": 15,
+            "w": 4,
+            "x": 4,
+            "y": 6
+          }
+        },
+        {
+          "card": {
+            "cardType": "datavis",
+            "title": "Requests",
+            "visualization": {
+              "config": {
+                "color": "Default",
+                "hideGridLines": true,
+                "legend": {
+                  "placement": "right",
+                  "type": "list"
+                },
+                "type": "xy",
+                "xConfig": {
+                  "visible": true
+                },
+                "yConfig": {
+                  "unit": "connections/sec",
+                  "visible": true
+                }
+              },
+              "source": {
+                "metric": {
+                  "aggregate": "avg",
+                  "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                  "description": "Auto Detected Metric",
+                  "groupBy": [
+                    [
+                      "controller_pod",
+                      "controller_namespace",
+                      "clusterUid"
+                    ],
+                    [
+                      "ingress",
+                      "exported_namespace",
+                      "clusterUid"
+                    ]
+                  ],
+                  "heuristics": null,
+                  "id": {
+                    "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                    "name": "nginx_ingress_controller_requests"
+                  },
+                  "interval": null,
+                  "link": {
+                    "__typename": "ForeignKey",
+                    "dstFields": [
+                      "name",
+                      "namespace",
+                      "clusterUid"
+                    ],
+                    "label": "Pod",
+                    "srcFields": [
+                      "controller_pod",
+                      "controller_namespace",
+                      "clusterUid"
+                    ],
+                    "targetDataset": "$dataset_kubernetes_pod",
+                    "targetStageLabel": null,
+                    "type": "foreign"
+                  },
+                  "name": "nginx_ingress_controller_requests",
+                  "rollup": "rate",
+                  "type": "gauge",
+                  "unit": "",
+                  "userDefined": false
+                },
+                "type": "metric"
+              },
+              "type": "timeseries"
+            }
+          },
+          "layout": {
+            "h": 15,
+            "w": 6,
+            "x": 0,
+            "y": 21
+          }
+        },
+        {
+          "card": {
+            "cardType": "datavis",
+            "title": "Connections",
+            "visualization": {
+              "config": {
+                "color": "Default",
+                "hideGridLines": true,
+                "legend": {
+                  "placement": "right",
+                  "type": "list"
+                },
+                "type": "xy",
+                "xConfig": {
+                  "visible": false
+                },
+                "yConfig": {
+                  "unit": "",
+                  "visible": true
+                }
+              },
+              "source": {
+                "metric": {
+                  "aggregate": "avg",
+                  "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                  "description": "Auto Detected Metric",
+                  "groupBy": [
+                    [
+                      "controller_pod",
+                      "controller_namespace",
+                      "clusterUid"
+                    ],
+                    "state"
+                  ],
+                  "heuristics": null,
+                  "id": {
+                    "datasetId": "$dataset_nginx-ingress_nginxIngressMetrics",
+                    "name": "nginx_ingress_controller_nginx_process_connections"
+                  },
+                  "interval": null,
+                  "link": {
+                    "__typename": "ForeignKey",
+                    "dstFields": [
+                      "name",
+                      "namespace",
+                      "clusterUid"
+                    ],
+                    "label": "Pod",
+                    "srcFields": [
+                      "controller_pod",
+                      "controller_namespace",
+                      "clusterUid"
+                    ],
+                    "targetDataset": "$dataset_kubernetes_pod",
+                    "targetStageLabel": null,
+                    "type": "foreign"
+                  },
+                  "name": "nginx_ingress_controller_nginx_process_connections",
+                  "rollup": "avg",
+                  "type": "gauge",
+                  "unit": "",
+                  "userDefined": false
+                },
+                "type": "metric"
+              },
+              "type": "timeseries"
+            }
+          },
+          "layout": {
+            "h": 15,
+            "w": 6,
+            "x": 6,
+            "y": 21
+          }
+        }
+      ]
+    },
+    {
+      "card": {
+        "cardType": "section",
+        "closed": false,
+        "title": "DOCUMENTATION"
+      },
+      "items": [
+        {
+          "card": {
+            "cardType": "text",
+            "text": "# NGINX Ingress Controller\nThe Ingress Controller is an application that runs in a cluster and configures an HTTP load balancer according to Ingress resources. The load balancer can be a software load balancer running in the cluster or a hardware or cloud load balancer running externally. Different load balancers require different Ingress Controller implementations.\n\nIn the case of NGINX, the Ingress Controller is deployed in a pod along with the load balancer.",
+            "title": "Text"
+          },
+          "layout": {
+            "h": 14,
+            "w": 6,
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "card": {
+            "cardType": "text",
+            "text": "# Notes\nFor resource consumption of the pod, use the CAdvisor Container Metrics board. Ingress-specific metrics for request latency, response latency, and upstream latency that can be found on the ingress resources.\n\nFrom here you can GraphLink to:\n* Ingress Logs\n* Container Logs\n* Cluster",
+            "title": "Text"
+          },
+          "layout": {
+            "h": 14,
+            "w": 6,
+            "x": 6,
+            "y": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/metrics.tf
+++ b/metrics.tf
@@ -1,0 +1,179 @@
+locals {
+  nginx_metrics = {
+    nginx_ingress_controller_response_upstream_latency_per_request = {
+      description = "Upstream latency per request in seconds"
+      type        = "gauge"
+      unit        = "seconds"
+    }
+    nginx_ingress_controller_response_latency_per_request = {
+      description = "Response latency per request in seconds"
+      type        = "gauge"
+      unit        = "seconds"
+    }
+    nginx_ingress_controller_request_latency_per_request = {
+      description = "Request latency in seconds"
+      type        = "gauge"
+      unit        = "seconds"
+    }
+    nginx_ingress_controller_config_last_reload_successful = {
+      description = "1 if last config reload was successful, 0 if last reload failed"
+      type        = "gauge"
+      rollup      = "min"
+      aggregate   = "min"
+    }
+    nginx_ingress_controller_requests = {
+      description = "Number of requests received by the nginx ingress controller"
+      type        = "gauge"
+    }
+    nginx_ingress_controller_nginx_process_connections = {
+      description = "Number of connections on the nginx ingress controller"
+      type        = "gauge"
+    }
+    nginx_ingress_controller_check_errors = {
+      description = "Total number of nginx ingress controller checks that have failed"
+      type        = "gauge"
+    }
+  }
+}
+
+resource "observe_dataset" "metrics" {
+  count     = var.enable_nginx_ingress_metrics ? 1 : 0
+  workspace = var.workspace.oid
+  name      = format(var.name_format, "Nginx Ingress Metrics")
+  freshness = var.freshness_default
+
+  inputs = {
+    "pod_metrics" = var.pod_metrics.metrics.oid
+  }
+
+  stage {
+    alias = "filtered_metrics"
+
+    pipeline = <<-EOF
+      filter starts_with(metric, "nginx_")
+
+      make_col 
+        exported_namespace: string(labels.exported_namespace),
+        controller_namespace:string(labels.controller_namespace),
+        controller_pod:string(labels.controller_pod),
+        status:string(labels.status),
+        state:string(labels.state),
+        ingress:string(labels.ingress)
+    EOF
+  }
+
+  stage {
+    alias = "request_latency"
+
+    pipeline = <<-EOF
+      align 15s,
+          request_latency_count:rate(m("nginx_ingress_controller_request_duration_seconds_count")),
+          request_latency_seconds:rate(m("nginx_ingress_controller_request_duration_seconds_sum")),
+          response_latency_count:rate(m("nginx_ingress_controller_response_duration_seconds_count")),
+          response_latency_seconds:rate(m("nginx_ingress_controller_response_duration_seconds_sum")),
+          upstream_latency_count:rate(m("nginx_ingress_controller_ingress_upstream_latency_seconds_count")),
+          upstream_latency_seconds:rate(m("nginx_ingress_controller_ingress_upstream_latency_seconds_sum"))
+
+      aggregate
+          request_latency_count:avg(request_latency_count),
+          request_latency_seconds:avg(request_latency_seconds),
+          response_latency_count:avg(response_latency_count),
+          response_latency_seconds:avg(response_latency_seconds),
+          upstream_latency_count:avg(upstream_latency_count),
+          upstream_latency_seconds:avg(upstream_latency_seconds),
+          group_by(clusterUid, namespace, ingress, pod, node, container, exported_namespace, controller_pod, controller_namespace, labels)
+      
+      make_event
+
+      make_col
+        metrics:make_object(
+          nginx_ingress_controller_response_upstream_latency_per_request:if((upstream_latency_seconds=0 and upstream_latency_count=0), 0, float64(upstream_latency_seconds/upstream_latency_count)),
+          nginx_ingress_controller_request_latency_per_request:if(request_latency_seconds=0 and request_latency_count=0, 0, float64(request_latency_seconds/request_latency_count)),
+          nginx_ingress_controller_response_latency_per_request:if(response_latency_seconds=0 and response_latency_count=0, 0, float64(response_latency_seconds/response_latency_count))
+        )
+      flatten_leaves metrics
+      
+      make_col metric:string(@."_c_metrics_path"),
+        value:float64(@."_c_metrics_value")
+      
+      pick_col
+        valid_from,
+        metric,
+        value,
+        node,
+        pod,
+        container,
+        namespace,
+        clusterUid,
+        labels,
+        exported_namespace,
+        controller_namespace,
+        controller_pod,
+        ingress
+          
+    EOF
+  }
+
+  stage {
+    input = "filtered_metrics"
+
+    pipeline = <<-EOF
+      union @request_latency
+
+      interface "metric", metric:metric, value:value
+
+      ${join("\n\n", [for metric, options in local.nginx_metrics : indent(2, format("set_metric options(\n%s\n), %q", join(",\n", [for k, v in options : format("%s: %q", k, v)]), metric))])}
+    EOF
+  }
+
+}
+
+resource "observe_link" "metrics" {
+  workspace = var.workspace.oid
+  source    = var.enable_nginx_ingress_metrics ? observe_dataset.metrics[0].oid : ""
+  target    = each.value.target
+  fields    = each.value.fields
+  label     = each.key
+
+  for_each = var.enable_nginx_ingress_metrics ? merge({
+    "Ingress" = {
+      target = var.kubernetes.ingress.oid
+      fields = ["ingress:name", "exported_namespace:namespace", "clusterUid"]
+    },
+    "Pod" = {
+      target = var.kubernetes.pod.oid
+      fields = ["controller_pod:name", "controller_namespace:namespace", "clusterUid"]
+    }
+    }
+  ) : {}
+}
+
+
+resource "observe_board" "ingress" {
+  count   = var.enable_nginx_ingress_metrics ? 1 : 0
+  dataset = var.kubernetes.ingress.oid
+  name    = "Nginx Ingress Monitoring"
+  type    = "set"
+
+  json = templatefile("${path.module}/boards/nginxIngressBoard.json", {
+    dataset_kubernetes_cluster   = regexall(":([^/:]*)(/|$)", var.kubernetes.cluster.oid)[0][0]     # extract id from oid
+    dataset_kubernetes_ingress   = regexall(":([^/:]*)(/|$)", var.kubernetes.ingress.oid)[0][0]     # extract id from oid
+    dataset_kubernetes_namespace = regexall(":([^/:]*)(/|$)", var.kubernetes.namespace.oid)[0][0]   # extract id from oid
+    ingress_nginxIngressMetrics  = regexall(":([^/:]*)(/|$)", observe_dataset.metrics[0].oid)[0][0] # extract id from oid
+  })
+}
+
+resource "observe_board" "pod" {
+  count   = var.enable_nginx_ingress_metrics ? 1 : 0
+  dataset = var.kubernetes.pod.oid
+  name    = "NGINX Ingress Controller Monitoring"
+  type    = "set"
+
+  json = templatefile("${path.module}/boards/nginxIngressPodBoard.json", {
+    dataset_kubernetes_cluster                = regexall(":([^/:]*)(/|$)", var.kubernetes.cluster.oid)[0][0]     # extract id from oid
+    dataset_kubernetes_pod                    = regexall(":([^/:]*)(/|$)", var.kubernetes.pod.oid)[0][0]         # extract id from oid
+    dataset_kubernetes_namespace              = regexall(":([^/:]*)(/|$)", var.kubernetes.namespace.oid)[0][0]   # extract id from oid
+    dataset_nginx-ingress_nginxIngressMetrics = regexall(":([^/:]*)(/|$)", observe_dataset.metrics[0].oid)[0][0] # extract id from oid
+    dataset_prometheus_podMetrics             = regexall(":([^/:]*)(/|$)", var.pod_metrics.metrics.oid)[0][0]    # extract id from oid
+  })
+}

--- a/variables.tf
+++ b/variables.tf
@@ -36,14 +36,32 @@ variable "pipeline_custom" {
   default     = null
 }
 
+variable "enable_nginx_ingress_metrics" {
+  type        = bool
+  description = "Flag to enable or disable nginx ingress metrics."
+  default     = true
+}
+
 
 variable "kubernetes" {
   type = object({
     container_logs = object({ oid = string })
     endpoint       = object({ oid = string })
+    ingress        = object({ oid = string })
+    pod            = object({ oid = string })
+    namespace      = object({ oid = string })
+    cluster        = object({ oid = string })
   })
   description = "Kubernetes module."
 }
+
+variable "pod_metrics" {
+  type = object({
+    metrics = object({ oid = string })
+  })
+  description = "Prometheus pod metrics module."
+}
+
 
 variable "link_targets" {
   description = "Datasets to link to."


### PR DESCRIPTION
## What does this PR do?

Creates an nginx ingress metrics dataset and links to kubernetes pod/ingress resources.  Adds boards on pods and ingresses.  Adds a flag for enabling/disabling metrics.

## Testing

Tested in my Observe instance with the flag enabled, disabled, and not defined (i.e. using default true).
